### PR TITLE
feat: Integrate Kanji API for dynamic content

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,51 +1,11 @@
-const kanjiLevels = {
-  N5: [
-    { character: "日", meaning: "sun, day" },
-    { character: "月", meaning: "moon, month" },
-    { character: "火", meaning: "fire" },
-    { character: "水", meaning: "water" },
-    { character: "木", meaning: "tree, wood" },
-    { character: "金", meaning: "gold, money" },
-    { character: "土", meaning: "earth, soil" },
-    { character: "山", meaning: "mountain" },
-    { character: "川", meaning: "river" },
-    { character: "田", meaning: "rice field" }
-  ],
-  N4: [
-    { character: "世", meaning: "world, generation" },
-    { character: "主", meaning: "master, main" },
-    { character: "仕", meaning: "serve, do" },
-    { character: "他", meaning: "other" },
-    { character: "代", meaning: "substitute, generation" }
-  ],
-  N3: [
-    { character: "億", meaning: "hundred million" },
-    { character: "加", meaning: "add" },
-    { character: "仮", meaning: "temporary" },
-    { character: "価", meaning: "value" },
-    { character: "河", meaning: "river" }
-  ],
-  N2: [
-    { character: "圧", meaning: "pressure" },
-    { character: "移", meaning: "shift, move" },
-    { character: "因", meaning: "cause, factor" },
-    { character: "永", meaning: "eternity" },
-    { character: "営", meaning: "manage, operate" }
-  ],
-  N1: [
-    { character: "曖", meaning: "unclear" },
-    { character: "握", meaning: "grip, hold" },
-    { character: "扱", meaning: "handle, deal with" },
-    { character: "宛", meaning: "address, direct to" },
-    { character: "嵐", meaning: "storm" }
-  ]
-};
-
 let currentKanji = null;
 let currentLevel = "N5";
-let currentKanjiList = kanjiLevels[currentLevel];
+let currentKanjiList = [];
 
 function getRandomKanji() {
+  if (currentKanjiList.length === 0) {
+    return { character: "Loading...", meaning: "Please wait" };
+  }
   const idx = Math.floor(Math.random() * currentKanjiList.length);
   return currentKanjiList[idx];
 }
@@ -53,18 +13,40 @@ function getRandomKanji() {
 function showKanji() {
   currentKanji = getRandomKanji();
   document.getElementById("kanji-character").textContent = currentKanji.character;
-  document.getElementById("kanji-meaning").textContent = "";
+  document.getElementById("kanji-meaning").textContent = ""; // Clear previous meaning
+
+  if (currentKanjiList.length === 0 && currentKanji.character !== "Loading...") {
+     document.getElementById("kanji-character").textContent = "Error";
+     document.getElementById("kanji-meaning").textContent = "Failed to load Kanji data.";
+  }
 }
 
 function showMeaning() {
-  if (currentKanji) {
+  if (currentKanji && currentKanji.meaning !== "Please wait" && currentKanji.meaning !== "Failed to load Kanji data.") {
     document.getElementById("kanji-meaning").textContent = currentKanji.meaning;
   }
 }
 
-function changeLevel(level) {
+async function changeLevel(level) {
   currentLevel = level;
-  currentKanjiList = kanjiLevels[currentLevel];
+  document.getElementById("kanji-character").textContent = "Loading...";
+  document.getElementById("kanji-meaning").textContent = "";
+
+  try {
+    const response = await fetch(`/api/kanji?level=${level}`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    currentKanjiList = await response.json();
+    if (currentKanjiList.length === 0) {
+        console.warn(`No Kanji found for level ${level}. Displaying message.`);
+        // Keep currentKanjiList as empty array
+    }
+  } catch (error) {
+    console.error("Failed to fetch kanji data:", error);
+    currentKanjiList = []; // Ensure list is empty on error
+    // Error is handled in showKanji
+  }
   showKanji();
 }
 
@@ -75,4 +57,4 @@ document.getElementById("jlpt-level").addEventListener("change", function (e) {
 });
 
 // Initialize with a kanji
-showKanji();
+changeLevel(currentLevel);


### PR DESCRIPTION
I modified the application to fetch Kanji data from the backend API (/api/kanji) instead of using hardcoded data.

Key changes:
- I removed the `kanjiLevels` object from `app.js`.
- I updated the `changeLevel` function in `app.js` to asynchronously fetch Kanji data for the selected JLPT level.
- I implemented loading and error states in `app.js` to inform you during API requests or if data fetching fails.
- I ensured that Kanji data for the default level (N5) is fetched and displayed when the page initially loads.
- The `server.js` provides the API endpoint, reading from `jlpt-vocab-api` data files.

I confirmed that the application successfully fetches and displays Kanji for different JLPT levels by querying the local server.