### PR TITLE
feat: Dynamically update Hiragana field

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,7 @@ async function getRandomKanji() {
 async function showKanji() {
   document.getElementById("kanji-character").textContent = "Loading...";
   document.getElementById("kanji-meaning").textContent = "";
+  document.getElementById("hiragana-text").textContent = "Loading..."; // Added this line
   
   currentKanji = await getRandomKanji();
 
@@ -46,6 +47,27 @@ async function showKanji() {
     kanjiCharEl.textContent = kanjiText;
     kanjiCharEl.title = "Click to hear pronunciation";
     kanjiCharEl.style.cursor = "pointer";
+
+    // Populate Hiragana reading
+    let hiraganaReading = null;
+    if (currentKanji.readings && currentKanji.readings.length > 0) {
+      hiraganaReading = currentKanji.readings[0];
+    } else if (currentKanji.reading) {
+      hiraganaReading = currentKanji.reading;
+    } else if (currentKanji.hiragana) {
+      hiraganaReading = currentKanji.hiragana;
+    } else if (currentKanji.kana) {
+      hiraganaReading = currentKanji.kana;
+    } else if (currentKanji.furigana) {
+      hiraganaReading = currentKanji.furigana;
+    }
+
+    const hiraganaTextEl = document.getElementById("hiragana-text");
+    if (hiraganaReading) {
+      hiraganaTextEl.textContent = hiraganaReading;
+    } else {
+      hiraganaTextEl.textContent = "-";
+    }
     
     // If meaning was visible before, show it for the new kanji too
     if (isMeaningVisible) {


### PR DESCRIPTION
I modified app.js to fetch and display Hiragana readings corresponding to the current Kanji.

The `showKanji()` function now:
- Sets a loading state for the Hiragana field.
- Extracts Hiragana data from the API response, checking properties in the order: `readings[0]`, `reading`, `hiragana`, `kana`, `furigana`.
- Updates the `#hiragana-text` div with the found reading, or displays '-' if no reading is available.